### PR TITLE
Use system variable for project name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,6 @@ steps:
   displayName: 'Publish NuGet package'
   inputs:
     command: push
-    publishVstsFeed: 'Space Game - web - Dependencies/Tailspin.SpaceGame.Web.Models'
+    publishVstsFeed: '$(System.TeamProject)/Tailspin.SpaceGame.Web.Models'
     allowPackageConflicts: true
   condition: succeeded()


### PR DESCRIPTION
My first attempt to run the pipeline failed as the name of my Azure DevOps project did not match the expected value (I did not create a new project for this learning module but continued to use the previously created one):

```
##[error]The nuget command failed with exit code(1) and error(Unable to load the service index for source https://pkgs.dev.azure.com/odonyde/Space%20Game%20-%20web%20-%20Dependencies/_packaging/Tailspin.SpaceGame.Web.Models/nuget/v3/index.json.
```

To avoid this issue, I suggest to use system variable `$(System.TeamProject)` instead of a hard-coded project name in `azure-pipelines.yml`.