### PR TITLE
Fix: Update Pipeline for .NET 8 and modern Ubuntu runner

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  dotnetSdkVersion: '6.x'
+  dotnetSdkVersion: '8.x'
 
 steps:
 - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'ubuntu-20.04'
+  vmImage: 'ubuntu-latest'
 
 variables:
   buildConfiguration: 'Release'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,8 +34,8 @@ steps:
     majorVersion: '1'
     minorVersion: '0'
     patchVersion: '0'
- 
-- task: NuGetCommand@2
+
+- task: DotNetCoreCLI@2
   displayName: 'Publish NuGet package'
   inputs:
     command: push


### PR DESCRIPTION
This PR updates the build pipeline to align with the project's current .NET target and modern GitHub-hosted runners.

- Updates VM image to ubuntu-latest
- Updates .NET SDK version from 6 to 8 to match project's target framework 
- Replaced nuget CLI with dotnet CLI for the publish step to remove dependency on Mono.

Tested on my private Azure DevOps instance; the pipeline succeeded and produced the expected artifact. 

 